### PR TITLE
Force List Expression to Infer Union Type of Member Types.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5038,16 +5038,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if t:
             return t
 
-        # if a ListExpr, just infer the item type directly
+        # try to infer directly
         if isinstance(e, ListExpr):
             item_types = [self.accept(item) for item in e.items]
             if not item_types:
-                # empty list, default to Any
                 item_type = AnyType(TypeOfAny.from_empty_collection)
             else:
-                # attempt to find a common supertype
+                # use all the element types
                 item_type = self.infer_item_type(item_types)
             return self.chk.named_generic_type(fullname, [item_type])
+
+        #!BUG this forces all list exprs to be forced (we don't want that)
 
         # Translate into type checking a generic function call.
         # Used for list and set expressions, as well as for tuples

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2452,3 +2452,10 @@ x + T  # E: Unsupported left operand type for + ("int")
 T()  # E: "TypeVar" not callable
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testListComprehensionWithUnionTypeGenerator]
+class A: pass
+class B: pass
+a = A()
+b = B()
+l3: list[A | B] = [x for x in [a, b]]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2453,9 +2453,22 @@ T()  # E: "TypeVar" not callable
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
 
-[case testListComprehensionWithUnionTypeGenerator]
+[case testListComprehensionWithTupleUnionTypeGenerator]
 class A: pass
 class B: pass
 a = A()
 b = B()
+l3: list[A | B] = [x for x in (a, b)]
 l3: list[A | B] = [x for x in [a, b]]
+
+[case testListComprehensionWithListUnionTypeGenerator]
+a = A()
+b = "foo"
+l3: list[A | str] = [x for x in (a, b)]
+l3: list[A | str] = [x for x in [a, b]]
+
+[case testListComprehensionWithImmutableTypeUnionTypeGenerator]
+a = 3.0
+b = 3
+l3: list[float | int] = [x for x in (a, b)]
+l3: list[float | int] = [x for x in [a, b]]


### PR DESCRIPTION
# Infer Union Types for List Expressions with Heterogeneous Elements

**Description:**

This PR forces the type inference for list expressions in mypy to correctly infer `Union` types when a list contains elements of different types that have no common supertype other than `object`. However, currently this forces this for all list expression type inferences and hence breaks everything else. A pretty quirky fix would be to track any list comprehension accesses since this only happens when a union type list is used in the generator portion of a list comprehension.

**Background:**

Before, when a list literal was constructed with elements of disparate types without a meaningful common superclass, mypy would default to inferring the list's type as `List[object]`. This behavior led to type-checking issues in scenarios where a more precise type was expected. 

For example:

```python
class A:
    pass

class B:
    pass

a = A()
b = B()

l3: list[A | B] = [x for x in [a, b]]  # This would cause a mypy error
```

However, while this fixes this issue, it also generalizes the entire list expression inference to be forced as well.